### PR TITLE
Add current dmp num

### DIFF
--- a/pages/app/evaluation.vue
+++ b/pages/app/evaluation.vue
@@ -6,6 +6,7 @@ import type { DmpElement } from "~/server/utils/splitMdByElements";
 const router = useRouter();
 const toast = useToast();
 
+const currentDmpIndex = useState<number>("dmpIndex");
 const overallSatisfaction = ref<number | null>(null);
 const overallAuthorshipGuess = ref<string | null>(null);
 const overallEvaluationsPerDmp = useState<
@@ -222,7 +223,7 @@ async function saveAllEvaluations() {
 <template>
   <div v-if="currentElements.length" class="mt-10 space-y-6">
     <div class="mb-4 text-lg text-gray-700">
-      <strong>Section-wise Evaluation ({{ currentPage + 1 }}/3)</strong>
+      <strong>DMP #{{ currentDmpIndex + 1 }} – Section-wise Evaluation ({{ currentPage + 1 }}/3)</strong>
     </div>
 
     <h1>


### PR DESCRIPTION
## Summary by Sourcery

Add state management for the current DMP index and display the current DMP number in the section-wise evaluation header.

New Features:
- Initialize a new state variable to track the current DMP index
- Display the current DMP number in the evaluation page header