### PR TITLE
Fix dark color issue

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,10 +1,4 @@
 <script setup lang="ts">
-const colorMode = useColorMode();
-
-const color = computed(() =>
-  colorMode.value === "dark" ? "#111827" : "white",
-);
-
 useHead({
   htmlAttrs: {
     lang: "en",
@@ -13,7 +7,7 @@ useHead({
   meta: [
     { charset: "utf-8" },
     { name: "viewport", content: "width=device-width, initial-scale=1" },
-    { name: "theme-color", content: color, key: "theme-color" },
+    { name: "theme-color", content: "white", key: "theme-color" },
   ],
 });
 

--- a/components/app/AppColorModeButton.vue
+++ b/components/app/AppColorModeButton.vue
@@ -1,24 +1,10 @@
 <script setup lang="ts">
-const colorMode = useColorMode();
-const isDark = computed({
-  get() {
-    return colorMode.value === "dark";
-  },
-  set() {
-    colorMode.preference = colorMode.value === "dark" ? "light" : "dark";
-  },
-});
+// color mode is disabled; no setup needed
 </script>
 
 <template>
   <ClientOnly>
-    <UButton
-      :icon="isDark ? 'i-heroicons-moon-20-solid' : 'i-heroicons-sun-20-solid'"
-      color="neutral"
-      variant="ghost"
-      aria-label="Theme"
-      @click="isDark = !isDark"
-    />
+    <div class="h-8 w-8" />
 
     <template #fallback>
       <div class="h-8 w-8" />

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,4 +18,7 @@ export default defineNuxtConfig({
     },
     sessionPassword: process.env.NUXT_SESSION_PASSWORD || "",
   },
+  ui: {
+    colorMode: false,
+  },
 });


### PR DESCRIPTION
## Summary by Sourcery

Disable dark mode support and remove broken color mode functionality across the app

Bug Fixes:
- Remove dark mode toggle button and associated logic to prevent theme inconsistencies

Enhancements:
- Set static theme-color meta tag to white instead of dynamic computation
- Add placeholder element for layout consistency in place of removed toggle

Build:
- Disable Nuxt UI color mode by setting ui.colorMode to false in nuxt.config.ts